### PR TITLE
feat: implement icon button

### DIFF
--- a/src/components/common/Button/IconButton.tsx
+++ b/src/components/common/Button/IconButton.tsx
@@ -14,7 +14,7 @@ const IconButton: React.FC<IconButtonProps> = ({
   return (
     <button
       onClick={onClick}
-      className={`h-[${size}px] w-[${size}px] flex items-center justify-center icons-default ${
+      className={`h-[${size}px] w-[${size}px] flex items-center justify-center icons-default cursor-pointer ${
         filled ? "icons-filled" : ""
       }`}
     >

--- a/src/components/common/Button/IconButton.tsx
+++ b/src/components/common/Button/IconButton.tsx
@@ -1,0 +1,26 @@
+interface IconButtonProps {
+  iconName: string;
+  size?: number;
+  filled?: boolean;
+  onClick?: () => void;
+}
+
+const IconButton: React.FC<IconButtonProps> = ({
+  iconName,
+  size = 24,
+  filled = false,
+  onClick = () => {},
+}) => {
+  return (
+    <button
+      onClick={onClick}
+      className={`h-[${size}px] w-[${size}px] flex items-center justify-center icons-default ${
+        filled ? "icons-filled" : ""
+      }`}
+    >
+      {iconName}
+    </button>
+  );
+};
+
+export default IconButton;


### PR DESCRIPTION
재사용 가능한 IconButton 컴포넌트가 추가

[props]
iconName: 표시할 아이콘의 이름 
size: 아이콘의 크기 (기본값은 24).
filled: filled 아이콘 여부 (기본값은 false)
onClick: 버튼 클릭 시 호출될 함수